### PR TITLE
Remove iterator checkers temporarily

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -594,26 +594,26 @@ def EnumCastOutOfRangeChecker : Checker<"EnumCastOutOfRange">,
   HelpText<"Check integer to enumeration casts for out of range values">,
   Documentation<HasAlphaDocumentation>;
 
-def IteratorModeling : Checker<"IteratorModeling">,
-  HelpText<"Models iterators of C++ containers">,
-  Documentation<NotDocumented>,
-  Hidden;
-
-def InvalidatedIteratorChecker : Checker<"InvalidatedIterator">,
-  HelpText<"Check for use of invalidated iterators">,
-  Dependencies<[IteratorModeling]>,
-  Documentation<HasAlphaDocumentation>;
-
-def IteratorRangeChecker : Checker<"IteratorRange">,
-  HelpText<"Check for iterators used outside their valid ranges">,
-  Dependencies<[IteratorModeling]>,
-  Documentation<HasAlphaDocumentation>;
-
-def MismatchedIteratorChecker : Checker<"MismatchedIterator">,
-  HelpText<"Check for use of iterators of different containers where iterators "
-           "of the same container are expected">,
-  Dependencies<[IteratorModeling]>,
-  Documentation<HasAlphaDocumentation>;
+// def IteratorModeling : Checker<"IteratorModeling">,
+//   HelpText<"Models iterators of C++ containers">,
+//   Documentation<NotDocumented>,
+//   Hidden;
+// 
+// def InvalidatedIteratorChecker : Checker<"InvalidatedIterator">,
+//   HelpText<"Check for use of invalidated iterators">,
+//   Dependencies<[IteratorModeling]>,
+//   Documentation<HasAlphaDocumentation>;
+// 
+// def IteratorRangeChecker : Checker<"IteratorRange">,
+//   HelpText<"Check for iterators used outside their valid ranges">,
+//   Dependencies<[IteratorModeling]>,
+//   Documentation<HasAlphaDocumentation>;
+// 
+// def MismatchedIteratorChecker : Checker<"MismatchedIterator">,
+//   HelpText<"Check for use of iterators of different containers where iterators "
+//            "of the same container are expected">,
+//   Dependencies<[IteratorModeling]>,
+//   Documentation<HasAlphaDocumentation>;
 
 def PlacementNewChecker : Checker<"PlacementNew">,
   HelpText<"Check if default placement new is provided with pointers to "
@@ -1362,10 +1362,10 @@ def ReportStmts : Checker<"ReportStmts">,
   HelpText<"Emits a warning for every statement.">,
   Documentation<NotDocumented>;
 
-def DebugIteratorModeling : Checker<"DebugIteratorModeling">,
-  HelpText<"Check the analyzer's understanding of C++ iterators">,
-  Dependencies<[IteratorModeling]>,
-  Documentation<NotDocumented>;
+// def DebugIteratorModeling : Checker<"DebugIteratorModeling">,
+//   HelpText<"Check the analyzer's understanding of C++ iterators">,
+//   Dependencies<[IteratorModeling]>,
+//   Documentation<NotDocumented>;
 
 } // end "debug"
 

--- a/clang/lib/StaticAnalyzer/Checkers/DebugIteratorModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/DebugIteratorModeling.cpp
@@ -187,10 +187,10 @@ ExplodedNode *DebugIteratorModeling::reportDebugMsg(llvm::StringRef Msg,
   return N;
 }
 
-void ento::registerDebugIteratorModeling(CheckerManager &mgr) {
-  mgr.registerChecker<DebugIteratorModeling>();
-}
-
-bool ento::shouldRegisterDebugIteratorModeling(const LangOptions &LO) {
-  return true;
-}
+// void ento::registerDebugIteratorModeling(CheckerManager &mgr) {
+//   mgr.registerChecker<DebugIteratorModeling>();
+// }
+// 
+// bool ento::shouldRegisterDebugIteratorModeling(const LangOptions &LO) {
+//   return true;
+// }

--- a/clang/lib/StaticAnalyzer/Checkers/InvalidatedIteratorChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/InvalidatedIteratorChecker.cpp
@@ -86,10 +86,10 @@ void InvalidatedIteratorChecker::reportBug(const StringRef &Message,
   C.emitReport(std::move(R));
 }
 
-void ento::registerInvalidatedIteratorChecker(CheckerManager &mgr) {
-  mgr.registerChecker<InvalidatedIteratorChecker>();
-}
-
-bool ento::shouldRegisterInvalidatedIteratorChecker(const LangOptions &LO) {
-  return true;
-}
+// void ento::registerInvalidatedIteratorChecker(CheckerManager &mgr) {
+//   mgr.registerChecker<InvalidatedIteratorChecker>();
+// }
+// 
+// bool ento::shouldRegisterInvalidatedIteratorChecker(const LangOptions &LO) {
+//   return true;
+// }

--- a/clang/lib/StaticAnalyzer/Checkers/IteratorModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/IteratorModeling.cpp
@@ -1630,10 +1630,10 @@ SymbolRef rebaseSymbol(ProgramStateRef State, SValBuilder &SVB,
 
 } // namespace
 
-void ento::registerIteratorModeling(CheckerManager &mgr) {
-  mgr.registerChecker<IteratorModeling>();
-}
-
-bool ento::shouldRegisterIteratorModeling(const LangOptions &LO) {
-  return true;
-}
+// void ento::registerIteratorModeling(CheckerManager &mgr) {
+//   mgr.registerChecker<IteratorModeling>();
+// }
+// 
+// bool ento::shouldRegisterIteratorModeling(const LangOptions &LO) {
+//   return true;
+// }

--- a/clang/lib/StaticAnalyzer/Checkers/IteratorRangeChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/IteratorRangeChecker.cpp
@@ -264,10 +264,10 @@ bool isEqual(ProgramStateRef State, SymbolRef Sym1, SymbolRef Sym2) {
 
 } // namespace
 
-void ento::registerIteratorRangeChecker(CheckerManager &mgr) {
-  mgr.registerChecker<IteratorRangeChecker>();
-}
-
-bool ento::shouldRegisterIteratorRangeChecker(const LangOptions &LO) {
-  return true;
-}
+// void ento::registerIteratorRangeChecker(CheckerManager &mgr) {
+//   mgr.registerChecker<IteratorRangeChecker>();
+// }
+// 
+// bool ento::shouldRegisterIteratorRangeChecker(const LangOptions &LO) {
+//   return true;
+// }

--- a/clang/lib/StaticAnalyzer/Checkers/MismatchedIteratorChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MismatchedIteratorChecker.cpp
@@ -286,10 +286,10 @@ void MismatchedIteratorChecker::reportBug(const StringRef &Message,
   C.emitReport(std::move(R));
 }
 
-void ento::registerMismatchedIteratorChecker(CheckerManager &mgr) {
-  mgr.registerChecker<MismatchedIteratorChecker>();
-}
-
-bool ento::shouldRegisterMismatchedIteratorChecker(const LangOptions &LO) {
-  return true;
-}
+// void ento::registerMismatchedIteratorChecker(CheckerManager &mgr) {
+//   mgr.registerChecker<MismatchedIteratorChecker>();
+// }
+// 
+// bool ento::shouldRegisterMismatchedIteratorChecker(const LangOptions &LO) {
+//   return true;
+// }


### PR DESCRIPTION
The iterator checkers are removed temporarily because they may crash Z3.
The source code of these checkers have moved to a separate directory
because CMake build system must not find them under the project tree if
no build target belongs to them.