### PR TITLE
Turn off reports in system headers

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/AnalyzerOptions.def
+++ b/clang/include/clang/StaticAnalyzer/Core/AnalyzerOptions.def
@@ -310,6 +310,10 @@ ANALYZER_OPTION(bool, ShouldEmitFixItHintsAsRemarks, "fixits-as-remarks",
                 "Emit fix-it hints as remarks for testing purposes",
                 false)
 
+ANALYZER_OPTION(bool, ShouldReportInSystemHeader, "report-in-system-header",
+                "Emit a bug report even if it is located in a system header.",
+                true)
+
 //===----------------------------------------------------------------------===//
 // Unsigned analyzer options.
 //===----------------------------------------------------------------------===//

--- a/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
@@ -2827,6 +2827,12 @@ void BugReporter::emitReport(std::unique_ptr<BugReport> R) {
   if (!ValidSourceLoc)
     return;
 
+  // The goal of system headers is that no diagnostic report is emitted in
+  // those.
+  if (!getAnalyzerOptions().ShouldReportInSystemHeader &&
+      R->getLocation().asLocation().isInSystemHeader())
+    return;
+
   // Compute the bug report's hash to determine its equivalence class.
   llvm::FoldingSetNodeID ID;
   R->Profile(ID);

--- a/clang/test/Analysis/analyzer-config.c
+++ b/clang/test/Analysis/analyzer-config.c
@@ -87,6 +87,7 @@
 // CHECK-NEXT: prune-paths = true
 // CHECK-NEXT: region-store-small-struct-limit = 2
 // CHECK-NEXT: report-in-main-source-file = false
+// CHECK-NEXT: report-in-system-header = true
 // CHECK-NEXT: serialize-stats = false
 // CHECK-NEXT: silence-checkers = ""
 // CHECK-NEXT: stable-report-filename = false
@@ -99,4 +100,4 @@
 // CHECK-NEXT: unroll-loops = false
 // CHECK-NEXT: widen-loops = false
 // CHECK-NEXT: [stats]
-// CHECK-NEXT: num-entries = 96
+// CHECK-NEXT: num-entries = 97

--- a/clang/test/Analysis/system-header.c
+++ b/clang/test/Analysis/system-header.c
@@ -1,0 +1,11 @@
+// RUN: %clang_analyze_cc1 -analyzer-opt-analyze-headers -analyzer-checker=security.FloatLoopCounter -analyzer-config report-in-system-header=false -isystem %S/system-include -verify %s
+
+#include <system-header.h>
+
+void normalFunction()
+{
+  for (float f = 0; f < 10; f += 1) // expected-warning {{Variable 'f' with floating point type 'float' should not be used as a loop counter}}
+    ;
+
+  systemFunction();
+}

--- a/clang/test/Analysis/system-include/system-header.h
+++ b/clang/test/Analysis/system-include/system-header.h
@@ -1,0 +1,5 @@
+void systemFunction()
+{
+  for (float f = 0; f < 10; f += 1)
+    ;
+}


### PR DESCRIPTION
Include paths can be signed as system header paths. The convention is
not to give any diagnostic reports in these system headers by any
analyzer tools. ClangSA gives reports in system header by default, but
this patch introduces an analyzer config option which prevents this
default behavior.