### PR TITLE
[clang][CrossTU] Invalidate parent map after get cross TU definition.

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -668,6 +668,12 @@ public:
 
   DynTypedNodeList getParents(const ast_type_traits::DynTypedNode &Node);
 
+  /// Invalidate parent maps.
+  /// The parent maps work like a cache.
+  /// It should be invalidated after the AST has been modified.
+  /// The data is recomputed when a next getParents() call is done.
+  void invalidateParentMaps();
+
   const clang::PrintingPolicy &getPrintingPolicy() const {
     return PrintingPolicy;
   }

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -10670,6 +10670,8 @@ ASTContext::getParents(const ast_type_traits::DynTypedNode &Node) {
   return P->getParents(Node);
 }
 
+void ASTContext::invalidateParentMaps() { Parents.clear(); }
+
 bool
 ASTContext::ObjCMethodsAreEqual(const ObjCMethodDecl *MethodDecl,
                                 const ObjCMethodDecl *MethodImpl) {

--- a/clang/lib/CrossTU/CrossTranslationUnit.cpp
+++ b/clang/lib/CrossTU/CrossTranslationUnit.cpp
@@ -718,6 +718,9 @@ CrossTranslationUnitContext::importDefinitionImpl(const T *D, ASTUnit *Unit) {
   assert(hasBodyOrInit(ToDecl) && "Imported Decl should have body or init.");
   ++NumGetCTUSuccess;
 
+  // Parent map is invalidated after changing the AST.
+  ToDecl->getASTContext().invalidateParentMaps();
+
   return ToDecl;
 }
 


### PR DESCRIPTION
Parent map of ASTContext is built once. If this happens and later
the TU is modified by getCrossTUDefinition the parent map does not
contain the newly imported objects and has to be re-created.

Invalidation of the parent map is added to the CrossTranslationUnitContext.
It could be added to ASTImporter as well but for now this task remains the
responsibility of the user of ASTImporter. Reason for this is mostly that
ASTImporter calls itself recursively.

Phabricator review for the same fix in llvm code:
https://reviews.llvm.org/D82568
In the current case it is needed to add a function to `ASTContext` because `ParentMapContext` is not available.
