### PR TITLE
[ADT] Fix for ImmutableMapRef

### DIFF
--- a/llvm/include/llvm/ADT/ImmutableMap.h
+++ b/llvm/include/llvm/ADT/ImmutableMap.h
@@ -355,7 +355,7 @@ public:
   unsigned getHeight() const { return Root ? Root->getHeight() : 0; }
 
   static inline void Profile(FoldingSetNodeID &ID, const ImmutableMapRef &M) {
-    ID.AddPointer(M.Root);
+    ID.AddPointer(M.Root.get());
   }
 
   inline void Profile(FoldingSetNodeID &ID) const { return Profile(ID, *this); }

--- a/llvm/unittests/ADT/ImmutableMapTest.cpp
+++ b/llvm/unittests/ADT/ImmutableMapTest.cpp
@@ -46,4 +46,47 @@ TEST(ImmutableMapTest, MultiElemIntMapTest) {
   EXPECT_EQ(3U, S2.getHeight());
 }
 
+TEST(ImmutableMapTest, EmptyIntMapRefTest) {
+  using int_int_map = ImmutableMapRef<int, int>;
+  ImmutableMapRef<int, int>::FactoryTy *f =
+    new ImmutableMapRef<int, int>::FactoryTy();
+
+  EXPECT_TRUE(int_int_map::getEmptyMap(f) == int_int_map::getEmptyMap(f));
+  EXPECT_FALSE(int_int_map::getEmptyMap(f) != int_int_map::getEmptyMap(f));
+  EXPECT_TRUE(int_int_map::getEmptyMap(f).isEmpty());
+
+  int_int_map S = int_int_map::getEmptyMap(f);
+  EXPECT_EQ(0u, S.getHeight());
+  EXPECT_TRUE(S.begin() == S.end());
+  EXPECT_FALSE(S.begin() != S.end());
+}
+
+TEST(ImmutableMapTest, MultiElemIntMapRefTest) {
+  ImmutableMapRef<int, int>::FactoryTy *f =
+    new ImmutableMapRef<int, int>::FactoryTy();
+
+  ImmutableMapRef<int, int> S = ImmutableMapRef<int, int>::getEmptyMap(f);
+
+  ImmutableMapRef<int, int> S2 = S.add(3, 10).add(4, 11).add(5, 12);
+
+  EXPECT_TRUE(S.isEmpty());
+  EXPECT_FALSE(S2.isEmpty());
+
+  EXPECT_EQ(nullptr, S.lookup(3));
+  EXPECT_EQ(nullptr, S.lookup(9));
+
+  EXPECT_EQ(10, *S2.lookup(3));
+  EXPECT_EQ(11, *S2.lookup(4));
+  EXPECT_EQ(12, *S2.lookup(5));
+
+  EXPECT_EQ(5, S2.getMaxElement()->first);
+  EXPECT_EQ(3U, S2.getHeight());
+}
+
+  TEST(ImmutableMapTest, MapOfMapRefsTest) {
+  ImmutableMap<int, ImmutableMapRef<int, int>>::Factory f;
+
+  EXPECT_TRUE(f.getEmptyMap() == f.getEmptyMap());
+  }
+
 }


### PR DESCRIPTION
The `Root` member of `ImmutableMapRef` was changed recently from a
plain pointer to `IntrusiveRefCntPtr`. However, the `Profile` member
function was not adjusted. This results in comilation error whenever
the `Profile` method is used on an `ImmutableMapRef`. This patch fixes
this issue and also adds unit tests for `ImmutableMapRef`. See bug
[[ https://bugs.llvm.org/show_bug.cgi?id=47863 | 47863 ]].

Differential Revision: https://reviews.llvm.org/D89486