### PR TITLE
[analyzer][StdLibraryFunctionsChecker] Fix typos in summaries of mmap and mmap64

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/StdLibraryFunctionsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/StdLibraryFunctionsChecker.cpp
@@ -1590,8 +1590,6 @@ void StdLibraryFunctionsChecker::initFunctionSummaries(
     }
 
     if (Off_tTy) {
-      Optional<RangeInt> Off_tMax = BVF.getMaxValue(*Off_tTy).getLimitedValue();
-
       // void *mmap(void *addr, size_t length, int prot, int flags, int fd,
       // off_t offset);
       addToFunctionSummaryMap(
@@ -1601,13 +1599,11 @@ void StdLibraryFunctionsChecker::initFunctionSummaries(
               .ArgConstraint(
                   ArgumentCondition(1, WithinRange, Range(1, SizeMax)))
               .ArgConstraint(
-                  ArgumentCondition(4, WithinRange, Range(0, *Off_tMax))));
+                  ArgumentCondition(4, WithinRange, Range(0, IntMax))));
     }
 
     Optional<QualType> Off64_tTy = lookupType("off64_t", ACtx);
-    Optional<RangeInt> Off64_tMax;
     if (Off64_tTy) {
-      Off64_tMax = BVF.getMaxValue(*Off_tTy).getLimitedValue();
       // void *mmap64(void *addr, size_t length, int prot, int flags, int fd,
       // off64_t offset);
       addToFunctionSummaryMap(
@@ -1617,7 +1613,7 @@ void StdLibraryFunctionsChecker::initFunctionSummaries(
               .ArgConstraint(
                   ArgumentCondition(1, WithinRange, Range(1, SizeMax)))
               .ArgConstraint(
-                  ArgumentCondition(4, WithinRange, Range(0, *Off64_tMax))));
+                  ArgumentCondition(4, WithinRange, Range(0, IntMax))));
     }
 
     // int pipe(int fildes[2]);

--- a/clang/test/Analysis/std-c-library-posix-crash.c
+++ b/clang/test/Analysis/std-c-library-posix-crash.c
@@ -1,0 +1,18 @@
+// RUN: %clang_analyze_cc1 \
+// RUN:   -analyzer-checker=core,apiModeling.StdCLibraryFunctions \
+// RUN:   -analyzer-config apiModeling.StdCLibraryFunctions:ModelPOSIX=true \
+// RUN:   -verify %s
+//
+// expected-no-diagnostics
+
+typedef long off_t;
+typedef long long off64_t;
+typedef unsigned long size_t;
+
+void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
+void *mmap64(void *addr, size_t length, int prot, int flags, int fd, off64_t offset);
+
+void test(long len) {
+  mmap(0, len, 2, 1, 0, 0);   // no-crash
+  mmap64(0, len, 2, 1, 0, 0); // no-crash
+}


### PR DESCRIPTION
The fd parameter of

  void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)

should be constrained to the range [0, IntMax] as that is of type int.
Constraining to the range [0, Off_tMax] would result in a crash as that is
of a signed type with the value of 0xff..f (-1).

The crash would happen when we try to apply the arg constraints.
At line 583: assert(Min <= Max), as 0 <= -1 is not satisfied

The mmap64 is fixed for the same reason.

Reviewed By: martong, vsavchenko

Differential Revision: https://reviews.llvm.org/D92307