### PR TITLE
[clang-tidy] Crash fix for bugprone-misplaced-pointer-arithmetic-in-a…

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/MisplacedPointerArithmeticInAllocCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/MisplacedPointerArithmeticInAllocCheck.cpp
@@ -77,9 +77,9 @@ void MisplacedPointerArithmeticInAllocCheck::check(
       CallName = "operator new[]";
     } else {
       const auto *CtrE = New->getConstructExpr();
-      if (!CtrE->getArg(CtrE->getNumArgs() - 1)
-               ->getType()
-               ->isIntegralOrEnumerationType())
+      if (!CtrE || !CtrE->getArg(CtrE->getNumArgs() - 1)
+                                     ->getType()
+                                     ->isIntegralOrEnumerationType())
         return;
       CallName = "operator new";
     }

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone-misplaced-pointer-arithmetic-in-alloc.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone-misplaced-pointer-arithmetic-in-alloc.cpp
@@ -51,3 +51,14 @@ void bad_new_array(int n, int m) {
   // CHECK-FIXES: p = new char[n - m] + 10;
   // FIXME: should be p = new char[n - m + 10];
 }
+
+namespace std {
+typedef decltype(sizeof(void*)) size_t;
+}
+
+void* operator new(std::size_t, void*);
+
+void placement_new_ptr(void *buf, C *old) {
+  C **p = new (buf) C*(old) + 1;
+  // CHECK-MESSAGES-NOT: :[[@LINE-1]]:11: warning: arithmetic operation is applied to the result of operator new() instead of its size-like argument
+}


### PR DESCRIPTION
…lloc

Placement new operators on non-object types cause crash in
`bugprone-misplaced-pointer-arithmetic-in-alloc`. This patch fixes this
issue.

Differential Revision: https://reviews.llvm.org/D87683